### PR TITLE
Changed `getTemplate()`

### DIFF
--- a/src/Field/TaxonomyFieldType.php
+++ b/src/Field/TaxonomyFieldType.php
@@ -21,7 +21,7 @@ class TaxonomyFieldType implements FieldInterface
     public function getTemplate()
     {
 
-        return '_taxonomylist.twig';
+        return '@bolt/_taxonomylist.twig';
     }
 
     public function getStorageType()


### PR DESCRIPTION
Using an exact namespaced path instead so the field works in repeaters