### PR TITLE
Fixed a bug and implemented multiple selections

### DIFF
--- a/src/Field/TaxonomyFieldType.php
+++ b/src/Field/TaxonomyFieldType.php
@@ -1,7 +1,8 @@
 <?php
 namespace Bolt\Extension\Soapbox\TaxonomyField\Field;
 
-use Bolt\Storage\Field\FieldInterface;
+use Bolt\Storage\Field\Type\FieldTypeBase;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * This class extends the base field type and looks after serializing and hydrating the field
@@ -9,7 +10,7 @@ use Bolt\Storage\Field\FieldInterface;
  *
  * @author Graham May <graham.may@soapbox.co.uk>
  */
-class TaxonomyFieldType implements FieldInterface
+class TaxonomyFieldType extends FieldTypeBase
 {
 
     public function getName()
@@ -27,15 +28,13 @@ class TaxonomyFieldType implements FieldInterface
     public function getStorageType()
     {
 
-        return 'text';
+        return Type::getType('json_array');
     }
 
     public function getStorageOptions()
     {
 
-        return [
-            'default' => ''
-        ];
+        return [];
     }
 
 }

--- a/src/Field/TaxonomyMultipleFieldType.php
+++ b/src/Field/TaxonomyMultipleFieldType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Extension\Soapbox\TaxonomyField\Field;
 
 use Bolt\Storage\Field\Type\FieldTypeBase;
@@ -10,13 +11,13 @@ use Doctrine\DBAL\Types\Type;
  *
  * @author Graham May <graham.may@soapbox.co.uk>
  */
-class TaxonomyFieldType extends FieldTypeBase
+class TaxonomyMultipleFieldType extends FieldTypeBase
 {
 
     public function getName()
     {
 
-        return 'taxonomylist';
+        return 'taxonomylistmultiple';
     }
 
     public function getTemplate()
@@ -28,15 +29,13 @@ class TaxonomyFieldType extends FieldTypeBase
     public function getStorageType()
     {
 
-        return Type::getType('text');
+        return Type::getType('json_array');
     }
 
     public function getStorageOptions()
     {
 
-        return [
-            'default' => ''
-        ];
+        return [];
     }
 
 }

--- a/src/Provider/TaxonomyFieldProvider.php
+++ b/src/Provider/TaxonomyFieldProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Extension\Soapbox\TaxonomyField\Provider;
 
 use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyFieldType;
+use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyMultipleFieldType;
 use Bolt\Storage\FieldManager;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -19,11 +20,13 @@ class TaxonomyFieldProvider implements ServiceProviderInterface
     {
 
         $app['storage.typemap']       = array_merge($app['storage.typemap'], [
-            'taxonomylist' => TaxonomyFieldType::class
+            'taxonomylist' => TaxonomyFieldType::class,
+            'taxonomylistmultiple' => TaxonomyMultipleFieldType::class,
         ]);
         $app['storage.field_manager'] = $app->share($app->extend('storage.field_manager', function (FieldManager $manager) {
 
             $manager->addFieldType('taxonomylist', new TaxonomyFieldType());
+            $manager->addFieldType('taxonomylistmultple', new TaxonomyMultipleFieldType());
 
             return $manager;
         }));

--- a/src/Provider/TaxonomyFieldProvider.php
+++ b/src/Provider/TaxonomyFieldProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Extension\Soapbox\TaxonomyField\Provider;
+
+use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyFieldType;
+use Bolt\Storage\FieldManager;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+
+/**
+ * This class extends the the service provider
+ *
+ * @author Robert Hunt <robert.hunt@soapbox.co.uk>
+ */
+class TaxonomyFieldProvider implements ServiceProviderInterface
+{
+
+    public function register(Application $app)
+    {
+
+        $app['storage.typemap']       = array_merge($app['storage.typemap'], [
+            'taxonomylist' => TaxonomyFieldType::class
+        ]);
+        $app['storage.field_manager'] = $app->share($app->extend('storage.field_manager', function (FieldManager $manager) {
+
+            $manager->addFieldType('taxonomylist', new TaxonomyFieldType());
+
+            return $manager;
+        }));
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/TaxonomyFieldExtension.php
+++ b/src/TaxonomyFieldExtension.php
@@ -3,6 +3,7 @@
 namespace Bolt\Extension\Soapbox\TaxonomyField;
 
 use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyFieldType;
+use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyMultipleFieldType;
 use Bolt\Extension\SimpleExtension;
 use Bolt\Extension\Soapbox\TaxonomyField\Provider\TaxonomyFieldProvider;
 
@@ -39,6 +40,7 @@ class TaxonomyFieldExtension extends SimpleExtension
 
         return [
             new TaxonomyFieldType(),
+            new TaxonomyMultipleFieldType(),
         ];
     }
 

--- a/src/TaxonomyFieldExtension.php
+++ b/src/TaxonomyFieldExtension.php
@@ -4,6 +4,7 @@ namespace Bolt\Extension\Soapbox\TaxonomyField;
 
 use Bolt\Extension\Soapbox\TaxonomyField\Field\TaxonomyFieldType;
 use Bolt\Extension\SimpleExtension;
+use Bolt\Extension\Soapbox\TaxonomyField\Provider\TaxonomyFieldProvider;
 
 /**
  * The main extension class.
@@ -22,6 +23,15 @@ class TaxonomyFieldExtension extends SimpleExtension
     {
 
         return 'Taxonomy List Field Type';
+    }
+
+    public function getServiceProviders()
+    {
+
+        return [
+            $this,
+            new TaxonomyFieldProvider()
+        ];
     }
 
     public function registerFields()

--- a/templates/bolt/_taxonomylist.twig
+++ b/templates/bolt/_taxonomylist.twig
@@ -3,7 +3,7 @@
 {% set option = {
 info:      field.info|default(''),
 label:     field.label,
-multiple:  (field.multiple is defined and field.multiple),
+multiple:  (field.type == 'taxonomylistmultiple'),
 required:  field.required|default(false),
 values:    [],
 default:   field.default|default(null),
@@ -49,15 +49,17 @@ default:   field.default|default(null),
 {% endif %}
 
 
-{% if field.sortable|default(false) %}
-    {% set oldclass = option.class %}
-    {% set option = option|merge({ class: oldclass~' select2-sortable wide'}) %}
-
-    {% set newvals = [] %}
+{# if we have (sorted) options present already, make sure their order is
+   maintained. We do this by first selecting the current values, and then
+   merging that with the entire array of values. See #6332. #}
+{% if option.sortable %}
+    {% set leadingvalues = [] %}
     {% for key, sel in selection %}
-        {% set newvals = newvals|merge({ (key):values[sel]}) %}
+        {% for value_key, value_sel in values if value_sel == sel %}
+            {% set leadingvalues = leadingvalues|merge({ (value_key): value_sel}) %}
+        {% endfor %}
     {% endfor %}
-    {% set values = unique(newvals, values) %}
+    {% set values = unique(leadingvalues, values) %}
 {% endif %}
 
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}
@@ -81,7 +83,7 @@ default:   field.default|default(null),
 'clear':     true,
 'id':        key,
 'multiple':  option.multiple,
-'name':      name ~ '[]',
+'name':      option.multiple ? name ~ '[]' : name,
 'options':   options,
 'required':  option.required
 } %}

--- a/templates/bolt/_taxonomylist.twig
+++ b/templates/bolt/_taxonomylist.twig
@@ -81,7 +81,7 @@ default:   field.default|default(null),
 'clear':     true,
 'id':        key,
 'multiple':  option.multiple,
-'name':      option.multiple ? name ~ '[]' : name,
+'name':      name ~ '[]',
 'options':   options,
 'required':  option.required
 } %}


### PR DESCRIPTION
Fixed bug where field was throwing an error due to it not being added to DBAL types map.

Added support for multiple selections within field (you can now use the `multiple: true` option in `contenttypes.yml`.
**This also converts singular selections to an array though which may be a major change**