### PR TITLE
Fix the storage bug for multiple array values

### DIFF
--- a/src/Field/TaxonomyFieldType.php
+++ b/src/Field/TaxonomyFieldType.php
@@ -22,6 +22,10 @@ class TaxonomyFieldType extends FieldTypeBase
     public function getStorageType()
     {
 
+        if ((isset($this->mapping['data']['multiple']) && ($this->mapping['data']['multiple'])) || (isset($this->mapping['multiple']) && ($this->mapping['multiple']))) {
+            return Type::getType('json_array');
+        }
+
         return Type::getType('text');
     }
 


### PR DESCRIPTION
Changed the storage function to return json encoded array when the field's attribute is set to multiple